### PR TITLE
Add a retry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ You can also specify a specific queue to push the jobs to :
 
     $ sidekiq-client -q my_queue push MyWorker OtherWorker
 
+You can specify that the job should not be retried, if it fails :
+
+    $ sidekiq-client -r false push MyWorker OtherWorker
+
+You can also specify the number of times a job should be retried, if it fails :
+
+    $ sidekiq-client -r 5 push MyWorker OtherWorker
+
 For help :
 
     $ sidekiq-client --help

--- a/spec/sidekiq_client_cli_spec.rb
+++ b/spec/sidekiq_client_cli_spec.rb
@@ -46,7 +46,8 @@ describe SidekiqClientCLI do
       @client.settings.command.should eq "push"
       @client.settings.command_args.should eq worker_klasses
       @client.settings.config_path.should eq SidekiqClientCLI::DEFAULT_CONFIG_PATH
-			@client.settings.queue.should eq SidekiqClientCLI::DEFAULT_QUEUE
+      @client.settings.queue.should eq SidekiqClientCLI::DEFAULT_QUEUE
+      @client.settings.retry.should eq SidekiqClientCLI::DEFAULT_RETRY
     end
 
     it "parses push with a configuration file" do
@@ -56,7 +57,7 @@ describe SidekiqClientCLI do
       @client.settings.command.should eq "push"
       @client.settings.command_args.should eq worker_klasses
       @client.settings.config_path.should eq "mysidekiq.conf"
-			@client.settings.queue.should eq SidekiqClientCLI::DEFAULT_QUEUE
+      @client.settings.queue.should eq SidekiqClientCLI::DEFAULT_QUEUE
     end
 
     it "parses push with a queue" do
@@ -66,7 +67,27 @@ describe SidekiqClientCLI do
       @client.settings.command.should eq "push"
       @client.settings.command_args.should eq worker_klasses
       @client.settings.config_path.should eq SidekiqClientCLI::DEFAULT_CONFIG_PATH
-			@client.settings.queue.should eq "my_queue"
+      @client.settings.queue.should eq "my_queue"
+    end
+
+    it 'parses push with a boolean retry' do
+      worker_klasses = %w{FirstWorker SecondWorker}
+      ARGV = %w{ -r false push }.concat(worker_klasses)
+      @client.parse
+      @client.settings.command.should eq "push"
+      @client.settings.command_args.should eq worker_klasses
+      @client.settings.config_path.should eq SidekiqClientCLI::DEFAULT_CONFIG_PATH
+      @client.settings.retry.should eq false
+    end
+
+    it 'parses push with an integer retry' do
+      worker_klasses = %w{FirstWorker SecondWorker}
+      ARGV = %w{ -r 42 push }.concat(worker_klasses)
+      @client.parse
+      @client.settings.command.should eq "push"
+      @client.settings.command_args.should eq worker_klasses
+      @client.settings.config_path.should eq SidekiqClientCLI::DEFAULT_CONFIG_PATH
+      @client.settings.retry.should eq 42
     end
 
   end
@@ -103,50 +124,98 @@ describe SidekiqClientCLI do
   end
 
   describe 'push' do
-    it "pushes the worker classes" do
-      klass1 = "FirstWorker"
-      klass2 = "SecondWorker"
-      settings = double("settings")
+    let(:settings) { double("settings") }
+    let(:klass1) { "FirstWorker" }
+    let(:klass2) { "SecondWorker" }
+
+    before(:each) do
       settings.stub(:command_args).and_return [klass1, klass2]
+    end
+
+    it "pushes the worker classes" do
       settings.stub(:queue).and_return SidekiqClientCLI::DEFAULT_QUEUE
+      settings.stub(:retry).and_return SidekiqClientCLI::DEFAULT_RETRY
       @client.settings = settings
 
-      Sidekiq::Client.should_receive(:push).with('class' => klass1, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE)
-      Sidekiq::Client.should_receive(:push).with('class' => klass2, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE)
+      Sidekiq::Client.should_receive(:push).with('class' => klass1, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE, 'retry' => SidekiqClientCLI::DEFAULT_RETRY)
+      Sidekiq::Client.should_receive(:push).with('class' => klass2, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE, 'retry' => SidekiqClientCLI::DEFAULT_RETRY)
 
       @client.push
     end
 
     it "pushes the worker classes to the correct queue" do
-			queue = "Queue"
-      klass1 = "FirstWorker"
-      klass2 = "SecondWorker"
-      settings = double("settings")
-      settings.stub(:command_args).and_return [klass1, klass2]
+      queue = "Queue"
       settings.stub(:queue).and_return queue
+      settings.stub(:retry).and_return SidekiqClientCLI::DEFAULT_RETRY
       @client.settings = settings
 
-      Sidekiq::Client.should_receive(:push).with('class' => klass1, 'args' => [], 'queue' => queue)
-      Sidekiq::Client.should_receive(:push).with('class' => klass2, 'args' => [], 'queue' => queue)
+      Sidekiq::Client.should_receive(:push).with('class' => klass1, 'args' => [], 'queue' => queue, 'retry' => SidekiqClientCLI::DEFAULT_RETRY)
+      Sidekiq::Client.should_receive(:push).with('class' => klass2, 'args' => [], 'queue' => queue, 'retry' => SidekiqClientCLI::DEFAULT_RETRY)
+
+      @client.push
+    end
+
+    it 'pushes the worker classes with retry disabled' do
+      retry_option = false
+      settings.stub(:queue).and_return SidekiqClientCLI::DEFAULT_QUEUE
+      settings.stub(:retry).and_return retry_option
+      @client.settings = settings
+
+      Sidekiq::Client.should_receive(:push).with('class' => klass1, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE, 'retry' => retry_option)
+      Sidekiq::Client.should_receive(:push).with('class' => klass2, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE, 'retry' => retry_option)
+
+      @client.push
+    end
+
+    it 'pushes the worker classes with a set retry number' do
+      retry_attempts = 5
+      settings.stub(:queue).and_return SidekiqClientCLI::DEFAULT_QUEUE
+      settings.stub(:retry).and_return retry_attempts
+      @client.settings = settings
+
+      Sidekiq::Client.should_receive(:push).with('class' => klass1, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE, 'retry' => retry_attempts)
+      Sidekiq::Client.should_receive(:push).with('class' => klass2, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE, 'retry' => retry_attempts)
 
       @client.push
     end
 
     it "prints and continues if an exception is raised" do
-      klass1 = "FirstWorker"
-      klass2 = "SecondWorker"
-      settings = double("settings")
-      settings.stub(:command_args).and_return [klass1, klass2]
       settings.stub(:queue).and_return SidekiqClientCLI::DEFAULT_QUEUE
+      settings.stub(:retry).and_return SidekiqClientCLI::DEFAULT_RETRY
       @client.settings = settings
 
-      Sidekiq::Client.should_receive(:push).with('class' => klass1, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE).and_raise
-      Sidekiq::Client.should_receive(:push).with('class' => klass2, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE)
+      Sidekiq::Client.should_receive(:push).with('class' => klass1, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE, 'retry' => SidekiqClientCLI::DEFAULT_RETRY).and_raise
+      Sidekiq::Client.should_receive(:push).with('class' => klass2, 'args' => [], 'queue' => SidekiqClientCLI::DEFAULT_QUEUE, 'retry' => SidekiqClientCLI::DEFAULT_RETRY)
 
       out = IOHelper.stdout_read do
         @client.push
       end
       out.should include("Failed to push")
+    end
+
+  end
+
+  describe 'cast_retry_option' do
+    subject { SidekiqClientCLI }
+
+    it 'returns false if the string matches false|f|no|n|0' do
+      subject.cast_retry_option('false').should == false
+      subject.cast_retry_option('f').should == false
+      subject.cast_retry_option('no').should == false
+      subject.cast_retry_option('n').should == false
+      subject.cast_retry_option('0').should == false
+    end
+
+    it 'returns true if the string matches true|t|yes|y' do
+      subject.cast_retry_option('true').should == true
+      subject.cast_retry_option('t').should == true
+      subject.cast_retry_option('yes').should == true
+      subject.cast_retry_option('y').should == true
+    end
+
+    it 'returns an integer if the passed string is an integer' do
+      subject.cast_retry_option('1').should == 1
+      subject.cast_retry_option('42').should == 42
     end
 
   end


### PR DESCRIPTION
Hi @didil,

So I consolidated my previous attempt (#3) to one option:

`-retry false` or `-r false` - Tells Sidekiq to not retry the job, if the job fails
`-retry 5` or `-r 5` - Tells Sidekiq to retry the job at most 5 times, if the job fails

This now mimics the options of sidekiq's advanced options (https://github.com/mperham/sidekiq/wiki/Advanced-Options#workers)
