### PR TITLE
Add Retry Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ You can also specify a specific queue to push the jobs to :
 
     $ sidekiq-client -q my_queue push MyWorker OtherWorker
 
+You can specify that the job should not be retried, if it fails :
+
+    $ sidekiq-client -r false push MyWorker OtherWorker
+
+You can also specify the number of times a job should be retried, if it fails :
+
+    $ sidekiq-client -r 5 push MyWorker OtherWorker
+
 For help :
 
     $ sidekiq-client --help

--- a/lib/sidekiq_client_cli.rb
+++ b/lib/sidekiq_client_cli.rb
@@ -12,6 +12,7 @@ class SidekiqClientCLI
     @settings = CLI.new do
       option :config_path, :short => :c, :default => DEFAULT_CONFIG_PATH, :description => "Sidekiq client config file path"
       option :queue, :short => :q, :description => "Queue to place job on"
+      option :retry, :short => :r, :cast => lambda { |r| SidekiqClientCLI.cast_retry_option(r) }, :description => "Retry option for job"
       argument :command, :description => "'push' to push a job to the queue"
       arguments :command_args, :required => false, :description => "command arguments"
     end.parse! do |settings|
@@ -23,12 +24,19 @@ class SidekiqClientCLI
     end
   end
 
+  def self.cast_retry_option(retry_option)
+    return true if !!retry_option.match(/^(true|t|yes|y)$/i)
+    return false if !!retry_option.match(/^(false|f|no|n|0)$/i)
+    return retry_option.to_i if !!retry_option.match(/^\d+$/)
+  end
+
   def run
     # load the config file
     load settings.config_path if File.exists?(settings.config_path)
 
-    # set queue if not given
+    # set queue or retry if they are not given
     settings.queue ||= Sidekiq.default_worker_options['queue']
+    settings.retry ||= Sidekiq.default_worker_options['retry']
 
     self.send settings.command.to_sym
   end
@@ -36,8 +44,11 @@ class SidekiqClientCLI
   def push
     settings.command_args.each do |arg|
       begin
-        jid = Sidekiq::Client.push('class' => arg, 'queue' => settings.queue, 'args' => [])
-        p "Posted #{arg} to queue '#{settings.queue}', Job ID : #{jid}"
+        jid = Sidekiq::Client.push({ 'class' => arg,
+                                     'queue' => settings.queue,
+                                     'args'  => [],
+                                     'retry' => settings.retry })
+        p "Posted #{arg} to queue '#{settings.queue}', Job ID : #{jid}, Retry : #{settings.retry}"
       rescue StandardError => ex
         p "Failed to push to queue : #{ex.message}"
       end


### PR DESCRIPTION
Hi @didil,

I fixed all the merge conflicts from #4 and followed what @Saicheg did with the changed default options

To review, this is a feature to add a retry option to the cli:

-retry false or -r false - Tells Sidekiq to not retry the job, if the job fails
-retry 5 or -r 5 - Tells Sidekiq to retry the job at most 5 times, if the job fails

This mimics the options of sidekiq's advanced options (https://github.com/mperham/sidekiq/wiki/Advanced-Options#workers)

I paired with @unicornzero on the merge conflict from my previous PR #4
