### PR TITLE
Returns exit 1 if a exception was raised while pushing.

### DIFF
--- a/bin/sidekiq-client
+++ b/bin/sidekiq-client
@@ -5,7 +5,7 @@ require_relative '../lib/sidekiq_client_cli'
 begin
   client = SidekiqClientCLI.new
   client.parse
-  client.run
+  client.run or exit 1
 rescue => e
   STDERR.puts e.message
   STDERR.puts e.backtrace.join("\n")

--- a/lib/sidekiq_client_cli.rb
+++ b/lib/sidekiq_client_cli.rb
@@ -41,18 +41,26 @@ class SidekiqClientCLI
     self.send settings.command.to_sym
   end
 
+  # Returns true if all args can be pushed successfully.
+  # Returns false if at least one exception occured.
   def push
-    settings.command_args.each do |arg|
-      begin
-        jid = Sidekiq::Client.push({ 'class' => arg,
-                                     'queue' => settings.queue,
-                                     'args'  => [],
-                                     'retry' => settings.retry })
-        p "Posted #{arg} to queue '#{settings.queue}', Job ID : #{jid}, Retry : #{settings.retry}"
-      rescue StandardError => ex
-        p "Failed to push to queue : #{ex.message}"
-      end
+    settings.command_args.inject(true) do |success, arg|
+      push_argument arg
     end
+  end
+
+  private
+
+  def push_argument(arg)
+    jid = Sidekiq::Client.push({ 'class' => arg,
+                                 'queue' => settings.queue,
+                                 'args'  => [],
+                                 'retry' => settings.retry })
+    p "Posted #{arg} to queue '#{settings.queue}', Job ID : #{jid}, Retry : #{settings.retry}"
+    true
+  rescue StandardError => ex
+    p "Failed to push to queue : #{ex.message}"
+    false
   end
 
 end


### PR DESCRIPTION
This behavior is especially helpful when used in a crontab, so one can detect errors and report them.

Thanks for writing this handy little tool.
