### PR TITLE
support sending per-job arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ You can also specify the number of times a job should be retried, if it fails :
 
     $ sidekiq-client -r 5 push MyWorker OtherWorker
 
+If your job requires arguments, you can specify them a la Rake (it uses Rake's task parser):
+
+    $ sidekiq-client push MyWorker[my-arg,my-other-arg]
+
 For help :
 
     $ sidekiq-client --help

--- a/lib/sidekiq_client_cli.rb
+++ b/lib/sidekiq_client_cli.rb
@@ -57,7 +57,7 @@ class SidekiqClientCLI
                                  'queue' => settings.queue,
                                  'args'  => klass_args,
                                  'retry' => settings.retry })
-    p "Posted #{arg} to queue '#{settings.queue}', Job ID : #{jid}, Retry : #{settings.retry}"
+    p "Posted #{klass} to queue '#{settings.queue}', Job ID : #{jid}, Retry : #{settings.retry}, Args : #{klass_args}"
     true
   rescue StandardError => ex
     p "Failed to push to queue : #{ex.message}"


### PR DESCRIPTION
I found the need to pass arguments to my jobs so I added the functionality.  I started off writing my own Regex to parse the parameters, then remembered that Rake did this also.  Jim's Regex's were a little more complex, but look like they are more exacting than mine, so I grabbed his parse_task_string method.

Cheers,

Kevin
